### PR TITLE
🐛  fix spawn locations menu

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -49,7 +49,7 @@ RegisterNetEvent('qb-spawn:client:setupSpawns', function(cData, new, apps)
                 for i = 1, (#houses), 1 do
                     myHouses[#myHouses+1] = {
                         house = houses[i].house,
-                        label = Houses[houses[i].house].adress,
+                        label = houses[i].house,
                     }
                 end
             end


### PR DESCRIPTION
Fixes issue with spawn locations not showing if a player owns a house. 
Only "Last Location" would show up.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? YES
- Does your code fit the style guidelines? YES
- Does your PR fit the contribution guidelines? YES
