### PR TITLE
refactor(client): launch thread when ui displays instead of idle.

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -22,19 +22,23 @@ local function launchDisableControlsThread()
     end)
 end
 
---- Displays the spawn UI and disables controls
----@param isChoosingSpawn boolean
-local function SetDisplay(isChoosingSpawn)
+---Displays the spawn UI and disables controls
+---@param isShowing boolean
+---@return void
+local function SetDisplay(isShowing)
+    -- sets the global variable to the value passed in
+    isChoosingSpawn = isShowing
+
     -- launches a thread to disable controls if showing the UI
-    if isChoosingSpawn then launchDisableControlsThread() end
-    
+    if isShowing then launchDisableControlsThread() end
+
     -- sets the focus to the NUI window
-    SetNuiFocus(isChoosingSpawn, isChoosingSpawn)
+    SetNuiFocus(isShowing, isShowing)
 
     -- sends a message to the NUI window to show or hide the UI
     SendNUIMessage({
         action = "showUi",
-        status = isChoosingSpawn
+        status = isShowing
     })
 end
 

--- a/client.lua
+++ b/client.lua
@@ -26,16 +26,9 @@ end
 ---@param isShowing boolean
 ---@return void
 local function setDisplay(isShowing)
-    -- sets the global variable to the value passed in
     isChoosingSpawn = isShowing
-
-    -- launches a thread to disable controls if showing the UI
     if isShowing then launchDisableControlsThread() end
-
-    -- sets the focus to the NUI window
     SetNuiFocus(isShowing, isShowing)
-
-    -- sends a message to the NUI window to show or hide the UI
     SendNUIMessage({
         action = "showUi",
         status = isShowing

--- a/client.lua
+++ b/client.lua
@@ -25,7 +25,7 @@ end
 ---Displays the spawn UI and disables controls
 ---@param isShowing boolean
 ---@return void
-local function SetDisplay(isShowing)
+local function setDisplay(isShowing)
     -- sets the global variable to the value passed in
     isChoosingSpawn = isShowing
 

--- a/client.lua
+++ b/client.lua
@@ -12,12 +12,19 @@ local cam2 = nil
 
 -- Functions
 
-local function SetDisplay(bool)
-    choosingSpawn = bool
-    SetNuiFocus(bool, bool)
+--- Displays the spawn UI and disables controls
+---@param isChoosingSpawn boolean
+local function SetDisplay(isChoosingSpawn)
+    -- launches a thread to disable controls if showing the UI
+    if choosingSpawn then launchDisableControlsThread() end
+    
+    -- sets the focus to the NUI window
+    SetNuiFocus(isChoosingSpawn, isChoosingSpawn)
+
+    -- sends a message to the NUI window to show or hide the UI
     SendNUIMessage({
         action = "showUi",
-        status = bool
+        status = isChoosingSpawn
     })
 end
 
@@ -209,13 +216,12 @@ end)
 
 -- Threads
 
-CreateThread(function()
-    while true do
-        Wait(0)
-        if choosingSpawn then
+-- Stops player from moving while choosing spawn
+function launchDisableControlsThread()
+    Citizen.CreateThread(function()
+        while choosingSpawn do
+            Citizen.Wait(0)
             DisableAllControlActions(0)
-        else
-            Wait(1000)
         end
-    end
-end)
+    end)
+end

--- a/client.lua
+++ b/client.lua
@@ -5,18 +5,28 @@ local pointCamCoords = 75
 local pointCamCoords2 = 0
 local cam1Time = 500
 local cam2Time = 1000
-local choosingSpawn = false
+local isChoosingSpawn = false
 local Houses = {}
 local cam = nil
 local cam2 = nil
 
 -- Functions
 
+-- Stops player from moving while choosing spawn
+local function launchDisableControlsThread()
+    CreateThread(function()
+        while isChoosingSpawn do
+            Wait(0)
+            DisableAllControlActions(0)
+        end
+    end)
+end
+
 --- Displays the spawn UI and disables controls
 ---@param isChoosingSpawn boolean
 local function SetDisplay(isChoosingSpawn)
     -- launches a thread to disable controls if showing the UI
-    if choosingSpawn then launchDisableControlsThread() end
+    if isChoosingSpawn then launchDisableControlsThread() end
     
     -- sets the focus to the NUI window
     SetNuiFocus(isChoosingSpawn, isChoosingSpawn)
@@ -86,7 +96,7 @@ RegisterNUICallback("exit", function(_, cb)
         action = "showUi",
         status = false
     })
-    choosingSpawn = false
+    isChoosingSpawn = false
     cb("ok")
 end)
 
@@ -213,15 +223,3 @@ RegisterNUICallback('spawnplayer', function(data, cb)
     end
     cb('ok')
 end)
-
--- Threads
-
--- Stops player from moving while choosing spawn
-function launchDisableControlsThread()
-    Citizen.CreateThread(function()
-        while choosingSpawn do
-            Citizen.Wait(0)
-            DisableAllControlActions(0)
-        end
-    end)
-end

--- a/client.lua
+++ b/client.lua
@@ -25,7 +25,7 @@ end
 ---Displays the spawn UI and disables controls
 ---@param isShowing boolean
 ---@return void
-local function SetDisplay(isShowing)
+local function setDisplay(isShowing)
     -- sets the global variable to the value passed in
     isChoosingSpawn = isShowing
 
@@ -55,7 +55,7 @@ RegisterNetEvent('qb-spawn:client:openUI', function(value)
         RenderScriptCams(true, false, 1, true, true)
     end)
     Wait(500)
-    SetDisplay(value)
+    setDisplay(value)
 end)
 
 RegisterNetEvent('qb-houses:client:setHouseConfig', function(houseConfig)
@@ -144,7 +144,7 @@ end)
 RegisterNUICallback('chooseAppa', function(data, cb)
     local ped = PlayerPedId()
     local appaYeet = data.appType
-    SetDisplay(false)
+    setDisplay(false)
     DoScreenFadeOut(500)
     Wait(5000)
     TriggerServerEvent("apartments:server:CreateApartment", appaYeet, Apartments.Locations[appaYeet].label)
@@ -161,7 +161,7 @@ RegisterNUICallback('chooseAppa', function(data, cb)
 end)
 
 local function PreSpawnPlayer()
-    SetDisplay(false)
+    setDisplay(false)
     DoScreenFadeOut(500)
     Wait(2000)
 end


### PR DESCRIPTION
**Describe Pull request**

`CreateThread(function()
    while true do
        Wait(0)
        if choosingSpawn then
            DisableAllControlActions(0)
        else
            Wait(1000)
        end
    end
end)
`

This thread runs no matter what. Hence making the script less optimized.

Since we only need this thread launched when choosingSpawn is true, why not launch it when that case occcurs?

I did so by noticing the only place it can be set to true is in the **SetDisplay** function.

Therefore I checked when its true and launched our thread instead.


If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest)
- No I have not
- Does your code fit the style guidelines? [yes/no]
- Says to ignore
- Does your PR fit the contribution guidelines? [yes/no]
- Says to ignore
