### PR TITLE
feat: Scaleform Areas

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -197,6 +197,14 @@ AddEventHandler('qb-spawn:client:setupSpawns', function()
         coords = lib.callback.await('qbx_spawn:server:getLastLocation')
     }
 
+    local Houses = lib.callback.await('qbx_spawn:server:getHouses')
+    for i = 1, #Houses, 1 do
+        config.spawns[#config.spawns+1] = {
+            label = Houses[i].label,
+            coords = Houses[i].coords
+        }
+    end
+
     Wait(400)
 
     managePlayer()

--- a/client/main.lua
+++ b/client/main.lua
@@ -19,6 +19,9 @@ local function stopCamera()
     SetCamActive(previewCam, false)
     DestroyCam(previewCam, true)
     RenderScriptCams(false, false, 1, true, true)
+
+    BeginScaleformMovieMethod(scaleform, 'CLEANUP')
+    EndScaleformMovieMethod()
 end
 
 local function managePlayer()
@@ -30,6 +33,23 @@ local function managePlayer()
     end)
 end
 
+local function CreateSpawnArea()
+
+    for i = 1, #config.spawns, 1 do
+        local spawn = config.spawns[i]
+        BeginScaleformMovieMethod(scaleform, 'ADD_AREA')
+        ScaleformMovieMethodAddParamInt(i)
+        ScaleformMovieMethodAddParamFloat(spawn.coords.x)
+        ScaleformMovieMethodAddParamFloat(spawn.coords.y)
+        ScaleformMovieMethodAddParamFloat(500.0)
+        ScaleformMovieMethodAddParamInt(255)
+        ScaleformMovieMethodAddParamInt(0)
+        ScaleformMovieMethodAddParamInt(0)
+        ScaleformMovieMethodAddParamInt(100)
+        EndScaleformMovieMethod()
+    end
+end
+
 local function setupMap()
     scaleform = RequestScaleformMovie('HEISTMAP_MP')
 
@@ -37,6 +57,8 @@ local function setupMap()
         while not HasScaleformMovieLoaded(scaleform) do
             Wait(0)
         end
+
+        CreateSpawnArea()
 
         while DoesCamExist(previewCam) do
             DrawScaleformMovie_3d(scaleform, -24.86, -593.38, 91.8, -180.0, -180.0, -20.0, 0.0, 2.0, 0.0, 3.815, 2.27, 1.0, 2)
@@ -47,29 +69,40 @@ end
 
 local function scaleformDetails(index)
     BeginScaleformMovieMethod(scaleform, 'ADD_HIGHLIGHT')
-    ScaleformMovieMethodAddParamInt(1)
+    ScaleformMovieMethodAddParamInt(index)
     ScaleformMovieMethodAddParamFloat(config.spawns[index].coords.x)
     ScaleformMovieMethodAddParamFloat(config.spawns[index].coords.y)
     ScaleformMovieMethodAddParamFloat(500.0)
-    ScaleformMovieMethodAddParamInt(255)
     ScaleformMovieMethodAddParamInt(0)
+    ScaleformMovieMethodAddParamInt(255)
     ScaleformMovieMethodAddParamInt(0)
     ScaleformMovieMethodAddParamInt(100)
     EndScaleformMovieMethod()
 
+    BeginScaleformMovieMethod(scaleform, 'COLOUR_AREA')
+    ScaleformMovieMethodAddParamInt(index)
+    ScaleformMovieMethodAddParamInt(0)
+    ScaleformMovieMethodAddParamInt(255)
+    ScaleformMovieMethodAddParamInt(0)
+    ScaleformMovieMethodAddParamInt(0)
+    EndScaleformMovieMethod()
+
     BeginScaleformMovieMethod(scaleform, 'ADD_TEXT')
-    ScaleformMovieMethodAddParamInt(1)
+    ScaleformMovieMethodAddParamInt(index)
     ScaleformMovieMethodAddParamTextureNameString(config.spawns[index].label)
     ScaleformMovieMethodAddParamFloat(config.spawns[index].coords.x)
     ScaleformMovieMethodAddParamFloat(config.spawns[index].coords.y - 500)
     ScaleformMovieMethodAddParamFloat(25 - math.random(0, 50))
     ScaleformMovieMethodAddParamInt(26)
+    ScaleformMovieMethodAddParamInt(100)
+    ScaleformMovieMethodAddParamInt(255)
+    ScaleformMovieMethodAddParamBool(true)
     EndScaleformMovieMethod()
 
     local randomCoords = arrowStart[math.random(1, #arrowStart)]
 
     BeginScaleformMovieMethod(scaleform, 'ADD_ARROW')
-    ScaleformMovieMethodAddParamInt(1)
+    ScaleformMovieMethodAddParamInt(index)
     ScaleformMovieMethodAddParamFloat(randomCoords.x)
     ScaleformMovieMethodAddParamFloat(randomCoords.y)
     ScaleformMovieMethodAddParamFloat(config.spawns[index].coords.x)
@@ -78,7 +111,7 @@ local function scaleformDetails(index)
     EndScaleformMovieMethod()
 
     BeginScaleformMovieMethod(scaleform, 'COLOUR_ARROW')
-    ScaleformMovieMethodAddParamInt(1)
+    ScaleformMovieMethodAddParamInt(index)
     ScaleformMovieMethodAddParamInt(255)
     ScaleformMovieMethodAddParamInt(0)
     ScaleformMovieMethodAddParamInt(0)
@@ -89,17 +122,27 @@ end
 local function updateScaleform()
     if previousButtonID == currentButtonID then return end
 
-    BeginScaleformMovieMethod(scaleform, 'REMOVE_HIGHLIGHT')
-    ScaleformMovieMethodAddParamInt(1)
-    EndScaleformMovieMethod()
+    for i = 1, #config.spawns, 1 do
+        BeginScaleformMovieMethod(scaleform, 'REMOVE_HIGHLIGHT')
+        ScaleformMovieMethodAddParamInt(i)
+        EndScaleformMovieMethod()
+    
+        BeginScaleformMovieMethod(scaleform, 'REMOVE_TEXT')
+        ScaleformMovieMethodAddParamInt(i)
+        EndScaleformMovieMethod()
+    
+        BeginScaleformMovieMethod(scaleform, 'REMOVE_ARROW')
+        ScaleformMovieMethodAddParamInt(i)
+        EndScaleformMovieMethod()
 
-    BeginScaleformMovieMethod(scaleform, 'REMOVE_TEXT')
-    ScaleformMovieMethodAddParamInt(1)
-    EndScaleformMovieMethod()
-
-    BeginScaleformMovieMethod(scaleform, 'REMOVE_ARROW')
-    ScaleformMovieMethodAddParamInt(1)
-    EndScaleformMovieMethod()
+        BeginScaleformMovieMethod(scaleform, 'COLOUR_AREA')
+        ScaleformMovieMethodAddParamInt(i)
+        ScaleformMovieMethodAddParamInt(255)
+        ScaleformMovieMethodAddParamInt(0)
+        ScaleformMovieMethodAddParamInt(0)
+        ScaleformMovieMethodAddParamInt(100)
+        EndScaleformMovieMethod()
+    end
 
     scaleformDetails(currentButtonID)
 end
@@ -111,7 +154,7 @@ local function inputHandler()
             currentButtonID = currentButtonID - 1
 
             if currentButtonID < 1 then
-                currentButtonID = 1
+                currentButtonID = #config.spawns
             end
 
             updateScaleform()
@@ -120,7 +163,7 @@ local function inputHandler()
             currentButtonID = currentButtonID + 1
 
             if currentButtonID > #config.spawns then
-                currentButtonID = #config.spawns
+                currentButtonID = 1
             end
 
             updateScaleform()

--- a/server/main.lua
+++ b/server/main.lua
@@ -2,3 +2,19 @@ lib.callback.register('qbx_spawn:server:getLastLocation', function(source)
     local player = exports.qbx_core:GetPlayer(source)
     return json.decode(MySQL.single.await('SELECT position FROM players WHERE citizenid = ?', {player.PlayerData.citizenid}).position)
 end)
+
+lib.callback.register('qbx_spawn:server:getHouses', function(source)
+    local player = exports.qbx_core:GetPlayer(source)
+    local houseData = {}
+    local playerHouses = MySQL.query.await('SELECT house FROM player_houses WHERE citizenid = ?', {player.PlayerData.citizenid})
+    for i = 1, #playerHouses, 1 do
+        local name = playerHouses[i].house
+        local locationData = MySQL.single.await('SELECT `coords`, `label` FROM houselocations WHERE name = ?', {name})
+        print(json.decode(locationData.coords).enter)
+        houseData[#houseData+1] = {
+            label = locationData.label,
+            coords = json.decode(locationData.coords).enter
+        }
+    end
+    return houseData
+end)


### PR DESCRIPTION
## Description

This just makes it so it populates the map with areas for all spawn points. When selecting a spawn, it hides the area and still uses the old highlight system. I felt as if not showing all valid spawns until selecting them was a weird choice, at first I thought there was only 1 spawn. I also did some other random shit like added drop shadow to the text, and Made it so it would set you to index 1 when scrolling through the locations and hitting the last one

![image](https://github.com/Qbox-project/qbx_spawn/assets/66404074/56be7dc4-d578-47f7-89c6-86478d62f7be)

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x ] My pull request fits the contribution guidelines & code conventions.
