### PR TITLE
fix: failed to load scaleformMovie

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -82,8 +82,8 @@ local function setupInstructionalScaleform()
 end
 
 local function setupMap()
-    scaleform = lib.requestScaleformMovie('HEISTMAP_MP') or 0
-    buttonsScaleform = lib.requestScaleformMovie('INSTRUCTIONAL_BUTTONS') or 0
+    scaleform = lib.requestScaleformMovie('HEISTMAP_MP', 5000) or 0
+    buttonsScaleform = lib.requestScaleformMovie('INSTRUCTIONAL_BUTTONS', 5000) or 0
     CreateThread(function()
         setupInstructionalScaleform()
         createSpawnArea()


### PR DESCRIPTION
## Description

Due to ox_lib changes, default 1000ms is not enough to load scaleformMovie, hence throwing an error in the console and preventing player from spawning. Error message: https://media.discordapp.net/attachments/1031968831595352085/1248638867448528948/image.png?ex=66646510&is=66631390&hm=eb65d4335577586de8dfd2297a844a60e96576eeb84780a0a84219fa01f20acb&=&format=webp&quality=lossless&width=1193&height=671

## Checklist

- [X] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [X] My pull request fits the contribution guidelines & code conventions.
