### PR TITLE
fix: load property spawns instead of house spawns

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -248,9 +248,9 @@ AddEventHandler('qb-spawn:client:setupSpawns', function()
         spawns[#spawns + 1] = config.spawns[i]
     end
 
-    local houses = lib.callback.await('qbx_spawn:server:getHouses')
-    for i = 1, #houses do
-        spawns[#spawns + 1] = houses[i]
+    local properties = lib.callback.await('qbx_spawn:server:getProperties')
+    for i = 1, #properties do
+        spawns[#spawns + 1] = properties[i]
     end
 
     Wait(400)

--- a/server/main.lua
+++ b/server/main.lua
@@ -3,16 +3,16 @@ lib.callback.register('qbx_spawn:server:getLastLocation', function(source)
     return json.decode(MySQL.single.await('SELECT position FROM players WHERE citizenid = ?', {player.PlayerData.citizenid}).position), player.PlayerData.metadata.currentPropertyId
 end)
 
-lib.callback.register('qbx_spawn:server:getHouses', function(source)
+lib.callback.register('qbx_spawn:server:getProperties', function(source)
     local player = exports.qbx_core:GetPlayer(source)
     local houseData = {}
-    local playerHouses = MySQL.query.await('SELECT house FROM player_houses WHERE citizenid = ?', {player.PlayerData.citizenid})
-    for i = 1, #playerHouses do
-        local name = playerHouses[i].house
-        local locationData = MySQL.single.await('SELECT `coords`, `label` FROM houselocations WHERE name = ?', {name})
+    local properties = MySQL.query.await('SELECT id, property_name, coords FROM properties WHERE owner = ?', {player.PlayerData.citizenid})
+    for i = 1, #properties do
+        local property = properties[i]
         houseData[#houseData + 1] = {
-            label = locationData.label,
-            coords = json.decode(locationData.coords).enter
+            label = property.property_name,
+            coords = json.decode(property.coords),
+            propertyId = property.id,
         }
     end
 


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

Since we use qbx_properties now, add properties as spawns instead of houses from qbx_houses.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
