### PR TITLE
refactor(server): don't query `properties` if resource isn't started

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -4,6 +4,10 @@ lib.callback.register('qbx_spawn:server:getLastLocation', function(source)
 end)
 
 lib.callback.register('qbx_spawn:server:getProperties', function(source)
+    if not GetResourceState('qbx_properties'):find('start') then
+        return {}
+    end
+
     local player = exports.qbx_core:GetPlayer(source)
     local houseData = {}
     local properties = MySQL.query.await('SELECT id, property_name, coords FROM properties WHERE owner = ?', {player.PlayerData.citizenid})


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

If `qbx_properties` isn't started/starting, don't attempt to query its database.
As a result `qbx_properties` won't be a forced dependency.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
