### PR TITLE
fix(client): external multicharacter use

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -240,7 +240,7 @@ local function inputHandler()
     stopCamera()
 end
 
-AddEventHandler('qb-spawn:client:setupSpawns', function()
+RegisterNetEvent('qb-spawn:client:setupSpawns', function()
     spawns = {}
 
     local lastCoords, lastPropertyId = lib.callback.await('qbx_spawn:server:getLastLocation')


### PR DESCRIPTION
## Description

When using an external multicharacter with qbx_spawn, the players get stuck on an infinite loading screen because it is unable to find this event. For some reason, we have it as an event handler instead of an actual event.

## Checklist

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
